### PR TITLE
Switch to bitnami/nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,27 @@ WORKDIR /app/
 RUN npm install
 RUN hugo --config=config.prod.toml
 
-
-FROM nginx:latest
+FROM bitnami/nginx:latest
 ENV \
     VERIFICATION_HUGO_BASE_URL=https://verify.govdigital.de/ \
     SHOW_DEMO_DISCLAIMER=none \
     DEPLOYMENT_STAGE=prod
 
-COPY docker/replace-markers.sh /docker-entrypoint.d/
-COPY --from=builder /app/public/ /usr/share/nginx/html/
+# this is necessary for the startup script
+# that creates config from environment vars
+USER root
+RUN chown 1001 /app
+COPY --from=builder --chown=1001 /app/public/ /app_template
+COPY --from=builder /app/docker/default.conf /opt/bitnami/nginx/conf/server_blocks/default.conf
+COPY --chmod=555 docker/replace-markers.sh /replace-markers.sh
+RUN chmod 555 /replace-markers.sh
+RUN mkdir /www && chown 1001 /www
+
+USER 1001
+
+COPY docker/entrypoint.sh /entrypoint.sh
+
+EXPOSE 8081
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/opt/bitnami/scripts/nginx/run.sh" ]

--- a/docker/default.conf
+++ b/docker/default.conf
@@ -1,0 +1,13 @@
+server {
+    listen 8081 default_server;
+
+    location / {
+        root /www;
+    }
+
+    error_page 500 502 503 504  /50x.html;
+    location = /50x.html {
+        root /www;
+    }
+
+}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+/replace-markers.sh
+
+# taken from https://github.com/bitnami/bitnami-docker-nginx/blob/master/1.19/debian-10/rootfs/opt/bitnami/scripts/nginx/entrypoint.sh
+# and adjusted
+
+set -o errexit
+set -o nounset
+set -o pipefail
+# set -o xtrace # Uncomment this line for debugging purpose
+
+# Load libraries
+. /opt/bitnami/scripts/libbitnami.sh
+. /opt/bitnami/scripts/libnginx.sh
+
+# Load NGINX environment variables
+. /opt/bitnami/scripts/nginx-env.sh
+
+print_welcome_page
+
+# Load NGINX environment variables
+if [[ "$*" = "/opt/bitnami/scripts/nginx/run.sh" ]]; then
+    info "** Starting NGINX setup **"
+    /opt/bitnami/scripts/nginx/setup.sh
+    info "** NGINX setup finished! **"
+fi
+
+echo ""
+exec "$@"

--- a/docker/replace-markers.sh
+++ b/docker/replace-markers.sh
@@ -1,11 +1,15 @@
+
 #!/bin/bash
 
 # replace the markers in any file.
 # we need to prepend the protocol, otherwise hugo will try to optimize.
 # we cannot use @@ for markers, as they will get escaped in some cases.
-find /usr/share/nginx/html -type f -exec \
+
+find /app_template -type f -exec \
     sed -i \
         -e "s%https://__VERIFICATION_HUGO_BASE_URL__%${VERIFICATION_HUGO_BASE_URL}%" \
         -e "s%__SHOW_DEMO_DISCLAIMER__%${SHOW_DEMO_DISCLAIMER}%" \
         -e "s%__DEPLOYMENT_STAGE__%${DEPLOYMENT_STAGE}%" \
         {} \;
+
+cp -a /app_template/* /www


### PR DESCRIPTION
The reason for that is, that there is, that the bitnami nginx
is guaranteed to be functional when starting with a nonzero uid.
This comes with the side effect, that the container no longer
exposes port 80, but is now exposing port 8081