### PR TITLE
UD-563: Enable Init Container to run with ro fs

### DIFF
--- a/docker/replace-markers.sh
+++ b/docker/replace-markers.sh
@@ -5,6 +5,9 @@
 # we need to prepend the protocol, otherwise hugo will try to optimize.
 # we cannot use @@ for markers, as they will get escaped in some cases.
 
+# This script should fail if anything goes wrong
+set -e
+
 cp -a /app_template/* /www
 
 find /www -type f -exec \

--- a/docker/replace-markers.sh
+++ b/docker/replace-markers.sh
@@ -5,7 +5,9 @@
 # we need to prepend the protocol, otherwise hugo will try to optimize.
 # we cannot use @@ for markers, as they will get escaped in some cases.
 
-find /app_template -type f -exec \
+cp -a /app_template/* /www
+
+find /www -type f -exec \
     sed -i \
         -e "s%https://__VERIFICATION_HUGO_BASE_URL__%${VERIFICATION_HUGO_BASE_URL}%" \
         -e "s%__SHOW_DEMO_DISCLAIMER__%${SHOW_DEMO_DISCLAIMER}%" \
@@ -21,5 +23,3 @@ find /app_template -type f -exec \
         -e "s%__ACCESS_TOKEN_IMMUNKARTE__%${ACCESS_TOKEN_IMMUNKARTE}%" \
         -e "s%__TRANSFORM_UPP2DCC_BASE_URL__%${TRANSFORM_UPP2DCC_BASE_URL}%" \
         {} \;
-
-cp -a /app_template/* /www


### PR DESCRIPTION
This is necessary to comply with the newly introduced Gatekeeper PSP,
that requires all containers to have security contexts on QA